### PR TITLE
Add basic routing and user location indicator

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'ui/views/map_screen.dart';
+import 'ui/views/home_screen.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -20,7 +21,11 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Map App',
       theme: ThemeData(primarySwatch: Colors.blue),
-      home: const MapScreen(),
+      initialRoute: '/',
+      routes: {
+        '/': (context) => const HomeScreen(),
+        '/current_location': (context) => const MapScreen(),
+      },
     );
   }
 }

--- a/lib/ui/views/home_screen.dart
+++ b/lib/ui/views/home_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Prova de Conceito')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => Navigator.of(context).pushNamed('/current_location'),
+          child: const Text('Localiza\u00e7\u00e3o atual com Mapbox'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/views/map_screen.dart
+++ b/lib/ui/views/map_screen.dart
@@ -35,6 +35,12 @@ class _MapScreenState extends ConsumerState<MapScreen> {
                 zoom: 14,
               ),
               onMapCreated: (MapboxMap mapboxMap) {
+                mapboxMap.location.updateSettings(
+                  const LocationComponentSettings(
+                    enabled: true,
+                    pulsingEnabled: true,
+                  ),
+                );
               },
             ),
     );


### PR DESCRIPTION
## Summary
- add HomeScreen with button to show current location using Mapbox
- define routes in `MaterialApp`
- enable map location puck with pulsing effect

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab1f436188327a36807794db1eaff